### PR TITLE
feat: 웨이팅 CRD 기능 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ ext {
 }
 
 dependencies {
+	// postgreSQL
+	runtimeOnly 'org.postgresql:postgresql'
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,11 @@ dependencies {
 	runtimeOnly 'org.postgresql:postgresql'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/dayaeyak/waiting/common/config/JpaConfig.java
+++ b/src/main/java/com/dayaeyak/waiting/common/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.dayaeyak.waiting.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/dayaeyak/waiting/common/entity/BaseEntity.java
+++ b/src/main/java/com/dayaeyak/waiting/common/entity/BaseEntity.java
@@ -19,7 +19,7 @@ public abstract class BaseEntity {
     protected LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(name = "updated_at", updatable = false, nullable = false)
+    @Column(name = "updated_at", updatable = true, nullable = false)
     protected LocalDateTime updatedAt;
 
     @Column(name = "deleted_at")

--- a/src/main/java/com/dayaeyak/waiting/common/entity/BaseEntity.java
+++ b/src/main/java/com/dayaeyak/waiting/common/entity/BaseEntity.java
@@ -1,0 +1,32 @@
+package com.dayaeyak.waiting.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", updatable = false, nullable = false)
+    protected LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    protected LocalDateTime deletedAt;
+
+    /* 소프트 삭제 메서드 */
+    public void delete(){
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dayaeyak/waiting/domain/controller/WaitingController.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/controller/WaitingController.java
@@ -1,0 +1,88 @@
+package com.dayaeyak.waiting.domain.controller;
+
+import com.dayaeyak.waiting.domain.dto.request.WaitingCreateRequestDto;
+import com.dayaeyak.waiting.domain.dto.request.WaitingRequestDto;
+import com.dayaeyak.waiting.domain.dto.response.WaitingCreateResponseDto;
+import com.dayaeyak.waiting.domain.dto.response.WaitingListResponseDto;
+import com.dayaeyak.waiting.domain.dto.response.WaitingResponseDto;
+import com.dayaeyak.waiting.domain.service.WaitingActionService;
+import com.dayaeyak.waiting.domain.service.WaitingService;
+import com.dayaeyak.waiting.utils.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/waitings")
+@RequiredArgsConstructor
+public class WaitingController {
+
+    private final WaitingService waitingService;
+    private final WaitingActionService waitingActionService;
+
+    // 웨이팅 등록
+    @PostMapping
+    public ResponseEntity<ApiResponse<WaitingCreateResponseDto>> createWaiting(
+            @Validated
+            @RequestBody WaitingCreateRequestDto requestDto){
+        WaitingCreateResponseDto responseDto = waitingService.register(requestDto);
+        return ApiResponse.success(201, "웨이팅이 등록되었습니다.", responseDto);
+    }
+
+    // 웨이팅 단건 조회
+    @GetMapping("/{waitingId}")
+    public ResponseEntity<ApiResponse<WaitingResponseDto>> getWaiting(
+            @Validated
+            @PathVariable Long waitingId,
+            @RequestBody WaitingRequestDto requestDto){
+        WaitingResponseDto responseDto = waitingService.getWaiting(requestDto);
+        return ApiResponse.success(200, "", responseDto);
+    }
+
+    // 가게별 웨이팅 목록 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<WaitingListResponseDto>> getWaitings(
+            @RequestParam Long restaurantId,
+            @RequestParam(required = false) String status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        WaitingListResponseDto responseDto = waitingService.getWaitings(restaurantId, status, page, size);
+        return ApiResponse.success(200, "", responseDto);
+    }
+
+
+    // 웨이팅 수정 액션 통합형 (check-in, delay, going, arrived, cancel, call, no-show ...)
+    @PostMapping("/{waitingId}/actions/{action}")
+    public ResponseEntity<ApiResponse<WaitingResponseDto>> performAction(
+            @PathVariable Long waitingId,
+            @PathVariable String action,
+            @RequestHeader(value = "Idempotency-Key", required = false) String idemKey,
+            @RequestBody(required = false) Map<String, Object> payload) {
+
+        WaitingResponseDto responseDto = waitingActionService.perform(waitingId, action, idemKey, payload);
+        // call 같은 비동기 액션은 202로도 가능
+        return ApiResponse.success(202, "웨이팅이 수정되었습니다.", responseDto);
+    }
+
+    // 웨이팅 단건 삭제
+    @DeleteMapping("/{waitingId}")
+    public ResponseEntity<ApiResponse<Void>> deleteWaiting(
+            @Validated
+            @PathVariable Long waitingId,
+            @RequestBody WaitingRequestDto requestDto){
+        waitingService.deleteWaiting(requestDto);
+        return ApiResponse.success(204, "웨이팅이 삭되었습니다.", null);
+    }
+
+    // 웨이팅 모든 음식점에서 전체 삭제
+    @DeleteMapping("/all")
+    public ResponseEntity<ApiResponse<Void>> deleteWaitingAll(
+            @Validated
+            @RequestBody WaitingRequestDto requestDto){
+        waitingService.deleteWaitingAll(requestDto);
+        return ApiResponse.success(204, "웨이팅이 삭되었습니다.", null);
+    }
+}

--- a/src/main/java/com/dayaeyak/waiting/domain/controller/WaitingController.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/controller/WaitingController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.math.BigInteger;
 import java.util.Map;
 
 @RestController
@@ -32,57 +33,56 @@ public class WaitingController {
         return ApiResponse.success(201, "웨이팅이 등록되었습니다.", responseDto);
     }
 
+
     // 웨이팅 단건 조회
     @GetMapping("/{waitingId}")
     public ResponseEntity<ApiResponse<WaitingResponseDto>> getWaiting(
             @Validated
-            @PathVariable Long waitingId,
-            @RequestBody WaitingRequestDto requestDto){
-        WaitingResponseDto responseDto = waitingService.getWaiting(requestDto);
-        return ApiResponse.success(200, "", responseDto);
+            @PathVariable BigInteger waitingId){
+        WaitingResponseDto responseDto = waitingService.getWaiting(waitingId);
+        return ApiResponse.success(200, "웨이팅 단건이 조회되었습니다. ", responseDto);
     }
 
     // 가게별 웨이팅 목록 조회
     @GetMapping
     public ResponseEntity<ApiResponse<WaitingListResponseDto>> getWaitings(
-            @RequestParam Long restaurantId,
-            @RequestParam(required = false) String status,
+            @RequestParam BigInteger restaurantId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
-        WaitingListResponseDto responseDto = waitingService.getWaitings(restaurantId, status, page, size);
+        WaitingListResponseDto responseDto = waitingService.getWaitings(restaurantId, page, size);
         return ApiResponse.success(200, "", responseDto);
     }
 
 
-    // 웨이팅 수정 액션 통합형 (check-in, delay, going, arrived, cancel, call, no-show ...)
-    @PostMapping("/{waitingId}/actions/{action}")
-    public ResponseEntity<ApiResponse<WaitingResponseDto>> performAction(
-            @PathVariable Long waitingId,
-            @PathVariable String action,
-            @RequestHeader(value = "Idempotency-Key", required = false) String idemKey,
-            @RequestBody(required = false) Map<String, Object> payload) {
+//    // 웨이팅 수정 액션 통합형 (check-in, delay, going, arrived, cancel, call, no-show ...)
+//    @PostMapping("/{waitingId}/actions/{action}")
+//    public ResponseEntity<ApiResponse<WaitingResponseDto>> performAction(
+//            @PathVariable Long waitingId,
+//            @PathVariable String action,
+//            @RequestHeader(value = "Idempotency-Key", required = false) String idemKey,
+//            @RequestBody(required = false) Map<String, Object> payload) {
+//
+//        WaitingResponseDto responseDto = waitingActionService.perform(waitingId, action, idemKey, payload);
+//        // call 같은 비동기 액션은 202로도 가능
+//        return ApiResponse.success(202, "웨이팅이 수정되었습니다.", responseDto);
+//    }
 
-        WaitingResponseDto responseDto = waitingActionService.perform(waitingId, action, idemKey, payload);
-        // call 같은 비동기 액션은 202로도 가능
-        return ApiResponse.success(202, "웨이팅이 수정되었습니다.", responseDto);
-    }
 
     // 웨이팅 단건 삭제
     @DeleteMapping("/{waitingId}")
     public ResponseEntity<ApiResponse<Void>> deleteWaiting(
             @Validated
-            @PathVariable Long waitingId,
-            @RequestBody WaitingRequestDto requestDto){
-        waitingService.deleteWaiting(requestDto);
+            @PathVariable BigInteger waitingId){
+        waitingService.deleteWaiting(waitingId);
         return ApiResponse.success(204, "웨이팅이 삭되었습니다.", null);
     }
 
     // 웨이팅 모든 음식점에서 전체 삭제
-    @DeleteMapping("/all")
+    @DeleteMapping("/all/{restaurantId}")
     public ResponseEntity<ApiResponse<Void>> deleteWaitingAll(
             @Validated
-            @RequestBody WaitingRequestDto requestDto){
-        waitingService.deleteWaitingAll(requestDto);
+            @PathVariable BigInteger restaurantId){
+        waitingService.deleteWaitingAll(restaurantId);
         return ApiResponse.success(204, "웨이팅이 삭되었습니다.", null);
     }
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/controller/WaitingController.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/controller/WaitingController.java
@@ -13,7 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.math.BigInteger;
+import java.lang.Long;
 import java.util.Map;
 
 @RestController
@@ -38,7 +38,7 @@ public class WaitingController {
     @GetMapping("/{waitingId}")
     public ResponseEntity<ApiResponse<WaitingResponseDto>> getWaiting(
             @Validated
-            @PathVariable BigInteger waitingId){
+            @PathVariable Long waitingId){
         WaitingResponseDto responseDto = waitingService.getWaiting(waitingId);
         return ApiResponse.success(200, "웨이팅 단건이 조회되었습니다. ", responseDto);
     }
@@ -46,7 +46,7 @@ public class WaitingController {
     // 가게별 웨이팅 목록 조회
     @GetMapping
     public ResponseEntity<ApiResponse<WaitingListResponseDto>> getWaitings(
-            @RequestParam BigInteger restaurantId,
+            @RequestParam Long restaurantId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         WaitingListResponseDto responseDto = waitingService.getWaitings(restaurantId, page, size);
@@ -72,17 +72,17 @@ public class WaitingController {
     @DeleteMapping("/{waitingId}")
     public ResponseEntity<ApiResponse<Void>> deleteWaiting(
             @Validated
-            @PathVariable BigInteger waitingId){
+            @PathVariable Long waitingId){
         waitingService.deleteWaiting(waitingId);
-        return ApiResponse.success(204, "웨이팅이 삭되었습니다.", null);
+        return ApiResponse.success(204, "웨이팅이 삭제되었습니다.", null);
     }
 
     // 웨이팅 모든 음식점에서 전체 삭제
     @DeleteMapping("/all/{restaurantId}")
     public ResponseEntity<ApiResponse<Void>> deleteWaitingAll(
             @Validated
-            @PathVariable BigInteger restaurantId){
+            @PathVariable Long restaurantId){
         waitingService.deleteWaitingAll(restaurantId);
-        return ApiResponse.success(204, "웨이팅이 삭되었습니다.", null);
+        return ApiResponse.success(204, "웨이팅이 삭제되었습니다.", null);
     }
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/request/WaitingCreateRequestDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/request/WaitingCreateRequestDto.java
@@ -1,4 +1,13 @@
 package com.dayaeyak.waiting.domain.dto.request;
 
+import lombok.Getter;
+
+import java.math.BigInteger;
+
+@Getter
 public class WaitingCreateRequestDto {
+    private BigInteger restaurantId;
+    private BigInteger datesId;
+    private BigInteger userId;
+    private Integer userCount;
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/request/WaitingCreateRequestDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/request/WaitingCreateRequestDto.java
@@ -1,0 +1,4 @@
+package com.dayaeyak.waiting.domain.dto.request;
+
+public class WaitingCreateRequestDto {
+}

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/request/WaitingCreateRequestDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/request/WaitingCreateRequestDto.java
@@ -2,12 +2,11 @@ package com.dayaeyak.waiting.domain.dto.request;
 
 import lombok.Getter;
 
-import java.math.BigInteger;
 
 @Getter
 public class WaitingCreateRequestDto {
-    private BigInteger restaurantId;
-    private BigInteger datesId;
-    private BigInteger userId;
+    private Long restaurantId;
+    private Long datesId;
+    private Long userId;
     private Integer userCount;
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/request/WaitingRequestDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/request/WaitingRequestDto.java
@@ -1,0 +1,4 @@
+package com.dayaeyak.waiting.domain.dto.request;
+
+public class WaitingRequestDto {
+}

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingCreateResponseDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingCreateResponseDto.java
@@ -1,4 +1,13 @@
 package com.dayaeyak.waiting.domain.dto.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigInteger;
+
+@Getter
+@AllArgsConstructor
 public class WaitingCreateResponseDto {
+    private BigInteger waitingId;
+
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingCreateResponseDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingCreateResponseDto.java
@@ -3,11 +3,10 @@ package com.dayaeyak.waiting.domain.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.math.BigInteger;
 
 @Getter
 @AllArgsConstructor
 public class WaitingCreateResponseDto {
-    private BigInteger waitingId;
+    private Long waitingId;
 
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingCreateResponseDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingCreateResponseDto.java
@@ -1,0 +1,4 @@
+package com.dayaeyak.waiting.domain.dto.response;
+
+public class WaitingCreateResponseDto {
+}

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingListResponseDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingListResponseDto.java
@@ -1,4 +1,11 @@
 package com.dayaeyak.waiting.domain.dto.response;
 
-public class WaitingListResponseDto {
+import java.util.List;
+
+public record WaitingListResponseDto(
+        long count,
+        List<WaitingResponseDto> data
+) {
+
+
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingListResponseDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingListResponseDto.java
@@ -1,0 +1,4 @@
+package com.dayaeyak.waiting.domain.dto.response;
+
+public class WaitingListResponseDto {
+}

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingResponseDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingResponseDto.java
@@ -4,15 +4,14 @@ import com.dayaeyak.waiting.domain.entity.Waiting;
 import com.dayaeyak.waiting.domain.enums.WaitingStatus;
 import lombok.Builder;
 
-import java.math.BigInteger;
 import java.sql.Time;
 
 @Builder
 public record WaitingResponseDto(
-        BigInteger waitingId,
-        BigInteger restaurantId,
-        BigInteger datesId,
-        BigInteger userId,
+        Long waitingId,
+        Long restaurantId,
+        Long datesId,
+        Long userId,
         Integer userCount,
         WaitingStatus waitingStatus,
         Time entry_time

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingResponseDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingResponseDto.java
@@ -1,0 +1,4 @@
+package com.dayaeyak.waiting.domain.dto.response;
+
+public class WaitingResponseDto {
+}

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingResponseDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingResponseDto.java
@@ -1,4 +1,34 @@
 package com.dayaeyak.waiting.domain.dto.response;
 
-public class WaitingResponseDto {
+import com.dayaeyak.waiting.domain.entity.Waiting;
+import com.dayaeyak.waiting.domain.enums.WaitingStatus;
+import lombok.Builder;
+
+import java.math.BigInteger;
+import java.sql.Time;
+
+@Builder
+public record WaitingResponseDto(
+        BigInteger waitingId,
+        BigInteger restaurantId,
+        BigInteger datesId,
+        BigInteger userId,
+        Integer userCount,
+        WaitingStatus waitingStatus,
+        Time entry_time
+        ) {
+
+    public static WaitingResponseDto from(Waiting waiting){
+        return WaitingResponseDto.builder()
+        .waitingId(waiting.getWaitingId())
+        .restaurantId(waiting.getRestaurantId())
+        .datesId(waiting.getDatesId())
+        .userId(waiting.getUserId())
+        .userCount(waiting.getUserCount())
+        .waitingStatus(waiting.getWaitingStatus())
+        .entry_time(waiting.getEntryTime())
+        .build();
+        }
+
+
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/entity/Waiting.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/entity/Waiting.java
@@ -1,0 +1,54 @@
+package com.dayaeyak.waiting.domain.entity;
+
+import com.dayaeyak.waiting.common.entity.BaseEntity;
+import com.dayaeyak.waiting.domain.enums.WaitingStatus;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigInteger;
+import java.sql.Time;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name = "waitings")
+public class Waiting extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "waiting_id")
+    private BigInteger waitingId;
+
+    @Column(name ="restaurant_id", nullable = false)
+    private BigInteger restaurantId;
+
+    @Column(name ="dates_id", nullable = false)
+    private BigInteger datesId;
+
+    @Column(name ="user_id", nullable = false)
+    private BigInteger userId;
+
+    @Column(name ="user_count", nullable = false)
+    private Integer userCount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name ="waiting_status", nullable = false, length = 32)
+    private WaitingStatus waitingStatus;
+
+    @Column(name ="entry_time")
+    private Time entryTime;
+
+    @Builder
+    public Waiting(BigInteger restaurantId,
+                   BigInteger datesId,
+                   BigInteger userId,
+                   Integer userCount,
+                   WaitingStatus waitingStatus){
+        this.restaurantId = restaurantId;
+        this.datesId = datesId;
+        this.userId = userId;
+        this.userCount = userCount;
+        this.waitingStatus = waitingStatus;
+    }
+}

--- a/src/main/java/com/dayaeyak/waiting/domain/entity/Waiting.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/entity/Waiting.java
@@ -3,18 +3,19 @@ package com.dayaeyak.waiting.domain.entity;
 import com.dayaeyak.waiting.common.entity.BaseEntity;
 import com.dayaeyak.waiting.domain.enums.WaitingStatus;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
-import java.math.BigInteger;
+import java.lang.Long;
 import java.sql.Time;
 
 @Getter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "waitings")
 @Where(clause = "deleted_at IS NULL")
 @SQLDelete(sql = "UPDATE waitings SET deleted_at = now() WHERE waiting_id = ?")
@@ -22,16 +23,16 @@ public class Waiting extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "waiting_id")
-    private BigInteger waitingId;
+    private Long waitingId;
 
     @Column(name ="restaurant_id", nullable = false)
-    private BigInteger restaurantId;
+    private Long restaurantId;
 
     @Column(name ="dates_id", nullable = false)
-    private BigInteger datesId;
+    private Long datesId;
 
     @Column(name ="user_id", nullable = false)
-    private BigInteger userId;
+    private Long userId;
 
     @Column(name ="user_count", nullable = false)
     private Integer userCount;
@@ -44,9 +45,9 @@ public class Waiting extends BaseEntity {
     private Time entryTime;
 
     @Builder
-    public Waiting(BigInteger restaurantId,
-                   BigInteger datesId,
-                   BigInteger userId,
+    public Waiting(Long restaurantId,
+                   Long datesId,
+                   Long userId,
                    Integer userCount,
                    WaitingStatus waitingStatus){
         this.restaurantId = restaurantId;

--- a/src/main/java/com/dayaeyak/waiting/domain/entity/Waiting.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/entity/Waiting.java
@@ -6,6 +6,8 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.math.BigInteger;
 import java.sql.Time;
@@ -14,6 +16,8 @@ import java.sql.Time;
 @Entity
 @NoArgsConstructor
 @Table(name = "waitings")
+@Where(clause = "deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE waitings SET deleted_at = now() WHERE waiting_id = ?")
 public class Waiting extends BaseEntity {
 
     @Id @GeneratedValue

--- a/src/main/java/com/dayaeyak/waiting/domain/entity/Waitings.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/entity/Waitings.java
@@ -1,4 +1,0 @@
-package com.dayaeyak.waiting.domain.entity;
-
-public class Waitings {
-}

--- a/src/main/java/com/dayaeyak/waiting/domain/entity/Waitings.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/entity/Waitings.java
@@ -1,0 +1,4 @@
+package com.dayaeyak.waiting.domain.entity;
+
+public class Waitings {
+}

--- a/src/main/java/com/dayaeyak/waiting/domain/enums/WaitingStatus.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/enums/WaitingStatus.java
@@ -1,0 +1,10 @@
+package com.dayaeyak.waiting.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WaitingStatus {
+    WAITING, CALLED, ENTERED, USER_COMING, USER_NOSHOW, OWNER_CALLED, USER_CALLED;
+}

--- a/src/main/java/com/dayaeyak/waiting/domain/repository/jpa/WaitingRepository.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/repository/jpa/WaitingRepository.java
@@ -6,14 +6,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.math.BigInteger;
+import java.lang.Long;
 import java.util.List;
 
 @Repository
-public interface WaitingRepository extends JpaRepository<Waiting, BigInteger> {
+public interface WaitingRepository extends JpaRepository<Waiting, Long> {
     Waiting save(Waiting waiting);
-    Page<Waiting> findByRestaurantIdAndDeletedAtIsNull(BigInteger restaurantId, Pageable pageable);
-    List<Waiting> findByRestaurantIdAndDeletedAtIsNull(BigInteger restaurantId);
+    Page<Waiting> findByRestaurantIdAndDeletedAtIsNull(Long restaurantId, Pageable pageable);
+    List<Waiting> findByRestaurantIdAndDeletedAtIsNull(Long restaurantId);
 
 }
 

--- a/src/main/java/com/dayaeyak/waiting/domain/repository/jpa/WaitingRepository.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/repository/jpa/WaitingRepository.java
@@ -1,13 +1,19 @@
 package com.dayaeyak.waiting.domain.repository.jpa;
 
 import com.dayaeyak.waiting.domain.entity.Waiting;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.math.BigInteger;
+import java.util.List;
 
 @Repository
 public interface WaitingRepository extends JpaRepository<Waiting, BigInteger> {
     Waiting save(Waiting waiting);
+    Page<Waiting> findByRestaurantIdAndDeletedAtIsNull(BigInteger restaurantId, Pageable pageable);
+    List<Waiting> findByRestaurantIdAndDeletedAtIsNull(BigInteger restaurantId);
+
 }
 

--- a/src/main/java/com/dayaeyak/waiting/domain/repository/jpa/WaitingRepository.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/repository/jpa/WaitingRepository.java
@@ -1,0 +1,13 @@
+package com.dayaeyak.waiting.domain.repository.jpa;
+
+import com.dayaeyak.waiting.domain.entity.Waiting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigInteger;
+
+@Repository
+public interface WaitingRepository extends JpaRepository<Waiting, BigInteger> {
+    Waiting save(Waiting waiting);
+}
+

--- a/src/main/java/com/dayaeyak/waiting/domain/service/WaitingActionService.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/service/WaitingActionService.java
@@ -1,0 +1,7 @@
+package com.dayaeyak.waiting.domain.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class WaitingActionService {
+}

--- a/src/main/java/com/dayaeyak/waiting/domain/service/WaitingService.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/service/WaitingService.java
@@ -1,10 +1,43 @@
 package com.dayaeyak.waiting.domain.service;
 
+import com.dayaeyak.waiting.domain.dto.request.WaitingCreateRequestDto;
+import com.dayaeyak.waiting.domain.dto.response.WaitingCreateResponseDto;
+import com.dayaeyak.waiting.domain.dto.response.WaitingResponseDto;
+import com.dayaeyak.waiting.domain.entity.Waiting;
+import com.dayaeyak.waiting.domain.enums.WaitingStatus;
+import com.dayaeyak.waiting.domain.repository.jpa.WaitingRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+
+
+
+import java.math.BigInteger;
 
 @Service
+@RequiredArgsConstructor
 public class WaitingService {
 
+    private final WaitingRepository waitingRepository;
 
+    public WaitingCreateResponseDto register(WaitingCreateRequestDto requestDto){
+        Waiting waiting = Waiting.builder()
+                .restaurantId(requestDto.getRestaurantId())
+                .datesId(requestDto.getDatesId())
+                .userId(requestDto.getUserId())
+                .userCount(requestDto.getUserCount())
+                .waitingStatus(WaitingStatus.WAITING)
+                .build();
+        Waiting savedWaiting = waitingRepository.save(waiting);
 
+        return new WaitingCreateResponseDto(savedWaiting.getWaitingId());
+    }
+
+    public WaitingResponseDto getWaiting(BigInteger waitingId){
+        Waiting waiting = waitingRepository.findById(waitingId)
+                .orElseThrow(() -> new EntityNotFoundException());
+        return WaitingResponseDto.from(waiting);
+    }
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/service/WaitingService.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/service/WaitingService.java
@@ -17,7 +17,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 
-import java.math.BigInteger;
 import java.util.List;
 
 @Service
@@ -40,14 +39,14 @@ public class WaitingService {
         return new WaitingCreateResponseDto(savedWaiting.getWaitingId());
     }
 
-    public WaitingResponseDto getWaiting(BigInteger waitingId){
+    public WaitingResponseDto getWaiting(Long waitingId){
         Waiting waiting = waitingRepository.findById(waitingId)
                 .orElseThrow(() -> new EntityNotFoundException());
         return WaitingResponseDto.from(waiting);
     }
 
     public WaitingListResponseDto getWaitings(
-            BigInteger restaurantId,
+            Long restaurantId,
             int page,
             int size
     ){
@@ -60,7 +59,7 @@ public class WaitingService {
         return new WaitingListResponseDto(result.getTotalElements(), data);
     }
 
-    public void deleteWaiting(BigInteger waitingId){
+    public void deleteWaiting(Long waitingId){
         Waiting waiting = waitingRepository.findById(waitingId)
                 .orElseThrow(() -> new EntityNotFoundException());
 
@@ -68,7 +67,7 @@ public class WaitingService {
         waiting.delete();
     }
 
-    public void deleteWaitingAll(BigInteger restaurantId){
+    public void deleteWaitingAll(Long restaurantId){
         List<Waiting> waitingList = waitingRepository.findByRestaurantIdAndDeletedAtIsNull(restaurantId);
         if (waitingList.isEmpty()) return;
 

--- a/src/main/java/com/dayaeyak/waiting/domain/service/WaitingService.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/service/WaitingService.java
@@ -2,21 +2,26 @@ package com.dayaeyak.waiting.domain.service;
 
 import com.dayaeyak.waiting.domain.dto.request.WaitingCreateRequestDto;
 import com.dayaeyak.waiting.domain.dto.response.WaitingCreateResponseDto;
+import com.dayaeyak.waiting.domain.dto.response.WaitingListResponseDto;
 import com.dayaeyak.waiting.domain.dto.response.WaitingResponseDto;
 import com.dayaeyak.waiting.domain.entity.Waiting;
 import com.dayaeyak.waiting.domain.enums.WaitingStatus;
 import com.dayaeyak.waiting.domain.repository.jpa.WaitingRepository;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.crossstore.ChangeSetPersister;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
-
 
 
 import java.math.BigInteger;
+import java.util.List;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class WaitingService {
 
@@ -39,5 +44,38 @@ public class WaitingService {
         Waiting waiting = waitingRepository.findById(waitingId)
                 .orElseThrow(() -> new EntityNotFoundException());
         return WaitingResponseDto.from(waiting);
+    }
+
+    public WaitingListResponseDto getWaitings(
+            BigInteger restaurantId,
+            int page,
+            int size
+    ){
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Waiting> result = waitingRepository.findByRestaurantIdAndDeletedAtIsNull(restaurantId, pageable);
+        List<WaitingResponseDto> data = result.getContent().stream()
+                .map(WaitingResponseDto::from)
+                .toList();
+
+        return new WaitingListResponseDto(result.getTotalElements(), data);
+    }
+
+    public void deleteWaiting(BigInteger waitingId){
+        Waiting waiting = waitingRepository.findById(waitingId)
+                .orElseThrow(() -> new EntityNotFoundException());
+
+        if (waiting.getDeletedAt() != null) return;
+        waiting.delete();
+    }
+
+    public void deleteWaitingAll(BigInteger restaurantId){
+        List<Waiting> waitingList = waitingRepository.findByRestaurantIdAndDeletedAtIsNull(restaurantId);
+        if (waitingList.isEmpty()) return;
+
+        for (Waiting waiting : waitingList){
+            if (waiting.getDeletedAt()==null) {
+                waiting.delete();
+            }
+        }
     }
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/service/WaitingService.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/service/WaitingService.java
@@ -1,0 +1,10 @@
+package com.dayaeyak.waiting.domain.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class WaitingService {
+
+
+
+}

--- a/src/main/java/com/dayaeyak/waiting/utils/ApiResponse.java
+++ b/src/main/java/com/dayaeyak/waiting/utils/ApiResponse.java
@@ -1,0 +1,33 @@
+package com.dayaeyak.waiting.utils;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private String message;
+    private T data;
+
+    public static <T> ResponseEntity<ApiResponse<T>> success(int status, T data) {
+        return ResponseEntity.status(status)
+                .body(new ApiResponse<>(null, data));
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> success(int status, String message) {
+        return ResponseEntity.status(status)
+                .body(new ApiResponse<>(message, null));
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> success(int status, String message, T data) {
+        return ResponseEntity.status(status)
+                .body(new ApiResponse<>(message, data));
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> error(int status, String message){
+        return ResponseEntity.status(status)
+                .body(new ApiResponse<>(message, null));
+    }
+
+}


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 간단한 요약 -->
웨이팅 등록, 조회, 삭제 기능을 추가했습니다. 

## 💫 구현 및 변경 사항 (Details)

<!--- 구체적인 개발 사항 -->
1. 웨이팅 등록
2. 웨이팅 단건 조회 
3. 레스토랑 아이디로 웨이팅 목록 조회
4. 웨이팅 단건 삭제
5. 레스토랑 아이디로 웨이팅 목록 삭제 


## 📸스크린샷 (선택)

<!--- API 테스트 결과 스크린샷 -->
<img width="719" height="755" alt="스크린샷 2025-09-10 오후 9 28 14" src="https://github.com/user-attachments/assets/9e563643-be41-45ba-af20-4422002e3a6e" />

## ✅ 체크리스트

- [x] 코드 정상 작동 테스트 완료
- [x] 관련 문서(API 문서, 위키 등) 업데이트
- [x] 팀의 코드 컨벤션/스타일 가이드 준수
- [x] Reviewers에 팀원 등록


## 💬 TODO 

1. Update 부분은 feat/waiting_alarm 브랜치에서 진행 예정
2. 글로벌 에러 처리 추가 예정
3. 사용자 권한별 처리 추가 예정
4. 레디스 붙여서 상태관리 예정


## 기타/주의사항
- 
- 
-