### PR TITLE
feat: 웨이팅 U 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,11 @@ ext {
 }
 
 dependencies {
-	// postgreSQL
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.2.6'
+
+	// PostgreSQL
 	runtimeOnly 'org.postgresql:postgresql'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/dayaeyak/waiting/common/config/RedisConfig.java
+++ b/src/main/java/com/dayaeyak/waiting/common/config/RedisConfig.java
@@ -1,0 +1,94 @@
+package com.dayaeyak.waiting.common.config;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+//@Configuration
+public class RedisConfig {
+//
+//    @Value("${spring.redis.host}")
+//    private String host;
+//
+//    @Value("${spring.redis.port}")
+//    private int port;
+//
+//    /**
+//     * Redis 연결을 위한 'Connection' 생성합니다.
+//     *
+//     * @return RedisConnectionFactory
+//     */
+//    @Bean
+//    public RedisConnectionFactory redisConnectionFactory() {
+//        return new LettuceConnectionFactory(host, port);
+//    }
+//
+//    /**
+//     * Redis 데이터 처리를 위한 템플릿을 구성합니다.
+//     * 해당 구성된 RedisTemplate을 통해서 데이터 통신으로 처리되는 대한 직렬화를 수행합니다.
+//     *
+//     * @return RedisTemplate<String, Object>
+//     */
+//    @Bean
+//    public RedisTemplate<String, Object> redisTemplate() {
+//        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+//
+//        // Redis를 연결합니다.
+//        redisTemplate.setConnectionFactory(redisConnectionFactory());
+//
+//        // Key-Value 형태로 직렬화를 수행합니다.
+//        redisTemplate.setKeySerializer(new StringRedisSerializer());
+//        redisTemplate.setValueSerializer(new StringRedisSerializer());
+//
+//        // Hash Key-Value 형태로 직렬화를 수행합니다.
+//        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+//        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+//
+//        // 기본적으로 직렬화를 수행합니다.
+//        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+//
+//        return redisTemplate;
+//    }
+//
+//    /**
+//     * 리스트에 접근하여 다양한 연산을 수행합니다.
+//     *
+//     * @return ListOperations<String, Object>
+//     */
+//    public ListOperations<String, Object> getListOperations() {
+//        return this.redisTemplate().opsForList();
+//    }
+//
+//    /**
+//     * 단일 데이터에 접근하여 다양한 연산을 수행합니다.
+//     *
+//     * @return ValueOperations<String, Object>
+//     */
+//    public ValueOperations<String, Object> getValueOperations() {
+//        return this.redisTemplate().opsForValue();
+//    }
+//
+//
+//    /**
+//     * Redis 작업중 등록, 수정, 삭제에 대해서 처리 및 예외처리를 수행합니다.
+//     *
+//     * @param operation
+//     * @return
+//     */
+//    public int executeOperation(Runnable operation) {
+//        try {
+//            operation.run();
+//            return 1;
+//        } catch (Exception e) {
+//            System.out.println("Redis 작업 오류 발생 :: " + e.getMessage());
+//            return 0;
+//        }
+//    }
+}

--- a/src/main/java/com/dayaeyak/waiting/domain/controller/NoShowController.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/controller/NoShowController.java
@@ -11,7 +11,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.math.BigInteger;
+import java.lang.Long;
+
 
 @Controller
 @RestController
@@ -35,7 +36,7 @@ public class NoShowController {
     @GetMapping("/{noShowId}")
     public ResponseEntity<ApiResponse<NoShowResponseDto>> getNoShow(
             @Validated
-            @PathVariable BigInteger noShowId){
+            @PathVariable Long noShowId){
         NoShowResponseDto responseDto = noshowService.getNoShow(noShowId);
         return ApiResponse.success(200, "노쇼유저가 조회되었습니다. ", responseDto);
     }
@@ -43,7 +44,7 @@ public class NoShowController {
     // 가게별 웨이팅 목록 조회
     @GetMapping
     public ResponseEntity<ApiResponse<NoShowListResponseDto>> getNoShows(
-            @RequestParam BigInteger restaurantId,
+            @RequestParam Long restaurantId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         NoShowListResponseDto responseDto = noshowService.getNoShows(restaurantId, page, size);
@@ -54,7 +55,7 @@ public class NoShowController {
     @DeleteMapping("/{noShowId}")
     public ResponseEntity<ApiResponse<Void>> deleteNoShow(
             @Validated
-            @PathVariable BigInteger noShowId){
+            @PathVariable Long noShowId){
         noshowService.deleteNoShow(noShowId);
         return ApiResponse.success(204, "노쇼유저가 삭되었습니다.", null);
     }
@@ -63,7 +64,7 @@ public class NoShowController {
     @DeleteMapping("/all/{restaurantId}")
     public ResponseEntity<ApiResponse<Void>> deleteNoShowAll(
             @Validated
-            @PathVariable BigInteger restaurantId){
+            @PathVariable Long restaurantId){
         noshowService.deleteNoShowAll(restaurantId);
         return ApiResponse.success(204, "노쇼유저가 삭되었습니다.", null);
     }

--- a/src/main/java/com/dayaeyak/waiting/domain/controller/WaitingController.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/controller/WaitingController.java
@@ -5,6 +5,7 @@ import com.dayaeyak.waiting.domain.dto.request.WaitingRequestDto;
 import com.dayaeyak.waiting.domain.dto.response.WaitingCreateResponseDto;
 import com.dayaeyak.waiting.domain.dto.response.WaitingListResponseDto;
 import com.dayaeyak.waiting.domain.dto.response.WaitingResponseDto;
+import com.dayaeyak.waiting.domain.dto.response.WaitingUpdateResponseDto;
 import com.dayaeyak.waiting.domain.service.WaitingActionService;
 import com.dayaeyak.waiting.domain.service.WaitingService;
 import com.dayaeyak.waiting.utils.ApiResponse;
@@ -53,19 +54,16 @@ public class WaitingController {
         return ApiResponse.success(200, "", responseDto);
     }
 
+    // 웨이팅 수정 액션 통합형
+    @PostMapping("/{waitingId}/actions/{action}")
+    public ResponseEntity<ApiResponse<WaitingUpdateResponseDto>> updateAction(
+            @PathVariable BigInteger waitingId,
+            @PathVariable String action,
+            @RequestBody(required = false) Map<String, Object> payload) {
+        WaitingUpdateResponseDto responseDto = waitingActionService.updateWaiting(waitingId, action, payload);
 
-//    // 웨이팅 수정 액션 통합형 (check-in, delay, going, arrived, cancel, call, no-show ...)
-//    @PostMapping("/{waitingId}/actions/{action}")
-//    public ResponseEntity<ApiResponse<WaitingResponseDto>> performAction(
-//            @PathVariable Long waitingId,
-//            @PathVariable String action,
-//            @RequestHeader(value = "Idempotency-Key", required = false) String idemKey,
-//            @RequestBody(required = false) Map<String, Object> payload) {
-//
-//        WaitingResponseDto responseDto = waitingActionService.perform(waitingId, action, idemKey, payload);
-//        // call 같은 비동기 액션은 202로도 가능
-//        return ApiResponse.success(202, "웨이팅이 수정되었습니다.", responseDto);
-//    }
+        return ApiResponse.success(202, "웨이팅이 수정되었습니다.", responseDto);
+    }
 
 
     // 웨이팅 단건 삭제

--- a/src/main/java/com/dayaeyak/waiting/domain/controller/WaitingController.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/controller/WaitingController.java
@@ -14,7 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.math.BigInteger;
+import java.lang.Long;
+
 import java.util.Map;
 
 @RestController
@@ -39,7 +40,7 @@ public class WaitingController {
     @GetMapping("/{waitingId}")
     public ResponseEntity<ApiResponse<WaitingResponseDto>> getWaiting(
             @Validated
-            @PathVariable BigInteger waitingId){
+            @PathVariable Long waitingId){
         WaitingResponseDto responseDto = waitingService.getWaiting(waitingId);
         return ApiResponse.success(200, "웨이팅 단건이 조회되었습니다. ", responseDto);
     }
@@ -47,7 +48,7 @@ public class WaitingController {
     // 가게별 웨이팅 목록 조회
     @GetMapping
     public ResponseEntity<ApiResponse<WaitingListResponseDto>> getWaitings(
-            @RequestParam BigInteger restaurantId,
+            @RequestParam Long restaurantId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         WaitingListResponseDto responseDto = waitingService.getWaitings(restaurantId, page, size);
@@ -57,7 +58,7 @@ public class WaitingController {
     // 웨이팅 수정 액션 통합형
     @PostMapping("/{waitingId}/actions/{action}")
     public ResponseEntity<ApiResponse<WaitingUpdateResponseDto>> updateAction(
-            @PathVariable BigInteger waitingId,
+            @PathVariable Long waitingId,
             @PathVariable String action,
             @RequestBody(required = false) Map<String, Object> payload) {
         WaitingUpdateResponseDto responseDto = waitingActionService.updateWaiting(waitingId, action, payload);
@@ -70,7 +71,7 @@ public class WaitingController {
     @DeleteMapping("/{waitingId}")
     public ResponseEntity<ApiResponse<Void>> deleteWaiting(
             @Validated
-            @PathVariable BigInteger waitingId){
+            @PathVariable Long waitingId){
         waitingService.deleteWaiting(waitingId);
         return ApiResponse.success(204, "웨이팅이 삭되었습니다.", null);
     }
@@ -79,7 +80,7 @@ public class WaitingController {
     @DeleteMapping("/all/{restaurantId}")
     public ResponseEntity<ApiResponse<Void>> deleteWaitingAll(
             @Validated
-            @PathVariable BigInteger restaurantId){
+            @PathVariable Long restaurantId){
         waitingService.deleteWaitingAll(restaurantId);
         return ApiResponse.success(204, "웨이팅이 삭되었습니다.", null);
     }

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/request/NoShowCreateRequestDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/request/NoShowCreateRequestDto.java
@@ -2,10 +2,10 @@ package com.dayaeyak.waiting.domain.dto.request;
 
 import lombok.Getter;
 
-import java.math.BigInteger;
+import java.lang.Long;
 
 @Getter
 public class NoShowCreateRequestDto {
-    private BigInteger restaurantId;
-    private BigInteger userId;
+    private Long restaurantId;
+    private Long userId;
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/request/WaitingCreateRequestDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/request/WaitingCreateRequestDto.java
@@ -2,12 +2,12 @@ package com.dayaeyak.waiting.domain.dto.request;
 
 import lombok.Getter;
 
-import java.math.BigInteger;
+import java.lang.Long;
 
 @Getter
 public class WaitingCreateRequestDto {
-    private BigInteger restaurantId;
-    private BigInteger datesId;
-    private BigInteger userId;
+    private Long restaurantId;
+    private Long datesId;
+    private Long userId;
     private Integer userCount;
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/request/WaitingUpdateRequestDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/request/WaitingUpdateRequestDto.java
@@ -2,11 +2,10 @@ package com.dayaeyak.waiting.domain.dto.request;
 
 import lombok.Getter;
 
-import java.math.BigInteger;
 
 @Getter
 public class WaitingUpdateRequestDto {
-    private BigInteger restaurantId;
-    private BigInteger userId;
-    private BigInteger waitingId;
+    private Long restaurantId;
+    private Long userId;
+    private Long waitingId;
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/request/WaitingUpdateRequestDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/request/WaitingUpdateRequestDto.java
@@ -1,0 +1,12 @@
+package com.dayaeyak.waiting.domain.dto.request;
+
+import lombok.Getter;
+
+import java.math.BigInteger;
+
+@Getter
+public class WaitingUpdateRequestDto {
+    private BigInteger restaurantId;
+    private BigInteger userId;
+    private BigInteger waitingId;
+}

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/response/NoShowCreateResponseDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/response/NoShowCreateResponseDto.java
@@ -3,10 +3,10 @@ package com.dayaeyak.waiting.domain.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.math.BigInteger;
+
 
 @Getter
 @AllArgsConstructor
 public class NoShowCreateResponseDto {
-    private BigInteger noShowId;
+    private Long noShowId;
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/response/NoShowResponseDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/response/NoShowResponseDto.java
@@ -3,13 +3,13 @@ package com.dayaeyak.waiting.domain.dto.response;
 import com.dayaeyak.waiting.domain.entity.NoShow;
 import lombok.Builder;
 
-import java.math.BigInteger;
+
 
 @Builder
 public record NoShowResponseDto (
-    BigInteger noShowId,
-    BigInteger restaurantId,
-    BigInteger userId
+    Long noShowId,
+    Long restaurantId,
+    Long userId
 ){
 
     public static NoShowResponseDto from(NoShow noshow){

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingCreateResponseDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingCreateResponseDto.java
@@ -3,11 +3,11 @@ package com.dayaeyak.waiting.domain.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.math.BigInteger;
+
 
 @Getter
 @AllArgsConstructor
 public class WaitingCreateResponseDto {
-    private BigInteger waitingId;
+    private Long waitingId;
 
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingResponseDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingResponseDto.java
@@ -4,15 +4,15 @@ import com.dayaeyak.waiting.domain.entity.Waiting;
 import com.dayaeyak.waiting.domain.enums.WaitingStatus;
 import lombok.Builder;
 
-import java.math.BigInteger;
+
 import java.sql.Time;
 
 @Builder
 public record WaitingResponseDto(
-        BigInteger waitingId,
-        BigInteger restaurantId,
-        BigInteger datesId,
-        BigInteger userId,
+        Long waitingId,
+        Long restaurantId,
+        Long datesId,
+        Long userId,
         Integer userCount,
         WaitingStatus waitingStatus,
         Time entry_time

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingUpdateResponseDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingUpdateResponseDto.java
@@ -1,0 +1,12 @@
+package com.dayaeyak.waiting.domain.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigInteger;
+
+@Getter
+@AllArgsConstructor
+public class WaitingUpdateResponseDto {
+    BigInteger waitingId;
+}

--- a/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingUpdateResponseDto.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/dto/response/WaitingUpdateResponseDto.java
@@ -3,10 +3,10 @@ package com.dayaeyak.waiting.domain.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.math.BigInteger;
+
 
 @Getter
 @AllArgsConstructor
 public class WaitingUpdateResponseDto {
-    BigInteger waitingId;
+    Long waitingId;
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/entity/NoShow.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/entity/NoShow.java
@@ -9,7 +9,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
-import java.math.BigInteger;
+import java.lang.Long;
+
 
 @Getter
 @Entity
@@ -21,17 +22,17 @@ public class NoShow extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "no_show_id")
-    private BigInteger noShowId;
+    private Long noShowId;
 
     @Column(name ="user_id", nullable = false)
-    private BigInteger userId;
+    private Long userId;
 
     @Column(name ="restaurant_id", nullable = false)
-    private BigInteger restaurantId;
+    private Long restaurantId;
 
     @Builder
-    public NoShow(BigInteger restaurantId,
-                   BigInteger userId){
+    public NoShow(Long restaurantId,
+                   Long userId){
         this.restaurantId = restaurantId;
         this.userId = userId;
     }

--- a/src/main/java/com/dayaeyak/waiting/domain/entity/Waiting.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/entity/Waiting.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -14,6 +15,7 @@ import java.sql.Time;
 
 @Getter
 @Entity
+@Setter
 @NoArgsConstructor
 @Table(name = "waitings")
 @Where(clause = "deleted_at IS NULL")

--- a/src/main/java/com/dayaeyak/waiting/domain/entity/Waiting.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/entity/Waiting.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
-import java.math.BigInteger;
+
 import java.sql.Time;
 
 @Getter
@@ -24,16 +24,16 @@ public class Waiting extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "waiting_id")
-    private BigInteger waitingId;
+    private Long waitingId;
 
     @Column(name ="restaurant_id", nullable = false)
-    private BigInteger restaurantId;
+    private Long restaurantId;
 
     @Column(name ="dates_id", nullable = false)
-    private BigInteger datesId;
+    private Long datesId;
 
     @Column(name ="user_id", nullable = false)
-    private BigInteger userId;
+    private Long userId;
 
     @Column(name ="user_count", nullable = false)
     private Integer userCount;
@@ -46,9 +46,9 @@ public class Waiting extends BaseEntity {
     private Time entryTime;
 
     @Builder
-    public Waiting(BigInteger restaurantId,
-                   BigInteger datesId,
-                   BigInteger userId,
+    public Waiting(Long restaurantId,
+                   Long datesId,
+                   Long userId,
                    Integer userCount,
                    WaitingStatus waitingStatus){
         this.restaurantId = restaurantId;

--- a/src/main/java/com/dayaeyak/waiting/domain/entity/WaitingOrder.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/entity/WaitingOrder.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
-
+import org.hibernate.validator.constraints.UniqueElements;
 
 
 @Getter
@@ -25,7 +25,7 @@ public class WaitingOrder extends BaseEntity {
     @Column(name ="waiting_seq", nullable = false)  @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long waitingSeq;
 
-    @Column(name = "waiting_id")
+    @Column(name = "waiting_id", unique = true, nullable = false)
     private Long waitingId;
 
     @Column(name ="restaurant_id", nullable = false)

--- a/src/main/java/com/dayaeyak/waiting/domain/entity/WaitingOrder.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/entity/WaitingOrder.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
-import java.math.BigInteger;
+
 
 @Getter
 @Entity
@@ -23,13 +23,13 @@ public class WaitingOrder extends BaseEntity {
 
     @Id
     @Column(name ="waiting_seq", nullable = false)  @GeneratedValue(strategy = GenerationType.SEQUENCE)
-    private BigInteger waitingSeq;
+    private Long waitingSeq;
 
     @Column(name = "waiting_id")
-    private BigInteger waitingId;
+    private Long waitingId;
 
     @Column(name ="restaurant_id", nullable = false)
-    private BigInteger restaurantId;
+    private Long restaurantId;
 
     @Enumerated(EnumType.STRING)
     @Column(name ="waiting_status", nullable = false, length = 32)
@@ -46,9 +46,9 @@ public class WaitingOrder extends BaseEntity {
 
     @Builder
     public WaitingOrder(
-            BigInteger waitingSeq,
-            BigInteger waitingId,
-            BigInteger restaurantId,
+            Long waitingSeq,
+            Long waitingId,
+            Long restaurantId,
             WaitingStatus waitingStatus,
             String initialTime,
             String deadline,
@@ -72,8 +72,8 @@ public class WaitingOrder extends BaseEntity {
 //public class WaitingOrder implements Serializable {
 //
 //    @Id
-//    private BigInteger waitingId;
-//    private BigInteger restaurantId;
+//    private Long waitingId;
+//    private Long restaurantId;
 //    private WaitingStatus waitingStatus;
 //    private String initialTime;
 //    private String deadline;
@@ -81,8 +81,8 @@ public class WaitingOrder extends BaseEntity {
 //
 //    @Builder
 //    public WaitingOrder(
-//            BigInteger waitingId,
-//            BigInteger restaurantId,
+//            Long waitingId,
+//            Long restaurantId,
 //            WaitingStatus waitingStatus,
 //            String initialTime,
 //            String deadline,

--- a/src/main/java/com/dayaeyak/waiting/domain/entity/WaitingOrder.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/entity/WaitingOrder.java
@@ -1,0 +1,99 @@
+package com.dayaeyak.waiting.domain.entity;
+
+import com.dayaeyak.waiting.common.entity.BaseEntity;
+import com.dayaeyak.waiting.domain.enums.WaitingStatus;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import java.math.BigInteger;
+
+@Getter
+@Entity
+@Setter
+@NoArgsConstructor
+@Table(name = "waiting_orders")
+@Where(clause = "deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE waiting_orders SET deleted_at = now() WHERE waiting_id = ?")
+public class WaitingOrder extends BaseEntity {
+
+    @Id
+    @Column(name ="waiting_seq", nullable = false)  @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private BigInteger waitingSeq;
+
+    @Column(name = "waiting_id")
+    private BigInteger waitingId;
+
+    @Column(name ="restaurant_id", nullable = false)
+    private BigInteger restaurantId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name ="waiting_status", nullable = false, length = 32)
+    private WaitingStatus waitingStatus;
+
+    @Column(name ="initial_time")
+    private String initialTime;
+
+    @Column(name ="deadline")
+    private String deadline;
+
+    @Column(name ="last_call_at")
+    private String lastCallAt;
+
+    @Builder
+    public WaitingOrder(
+            BigInteger waitingSeq,
+            BigInteger waitingId,
+            BigInteger restaurantId,
+            WaitingStatus waitingStatus,
+            String initialTime,
+            String deadline,
+            String lastCallAt
+
+    ) {
+        this.waitingSeq = waitingSeq;
+        this.waitingId = waitingId;
+        this.restaurantId = restaurantId;
+        this.waitingStatus = waitingStatus;
+        this.initialTime = initialTime;
+        this.deadline = null;
+        this.lastCallAt = null;
+    }
+}
+
+//@Getter
+//@Setter
+//@NoArgsConstructor
+//@RedisHash("waiting")
+//public class WaitingOrder implements Serializable {
+//
+//    @Id
+//    private BigInteger waitingId;
+//    private BigInteger restaurantId;
+//    private WaitingStatus waitingStatus;
+//    private String initialTime;
+//    private String deadline;
+//    private String lastCallAt;
+//
+//    @Builder
+//    public WaitingOrder(
+//            BigInteger waitingId,
+//            BigInteger restaurantId,
+//            WaitingStatus waitingStatus,
+//            String initialTime,
+//            String deadline,
+//            String lastCallAt
+//
+//    ) {
+//        this.waitingId = waitingId;
+//        this.restaurantId = restaurantId;
+//        this.waitingStatus = waitingStatus;
+//        this.initialTime = initialTime;
+//        this.deadline = null;
+//        this.lastCallAt = null;
+//    }
+//}

--- a/src/main/java/com/dayaeyak/waiting/domain/enums/CallType.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/enums/CallType.java
@@ -1,0 +1,4 @@
+package com.dayaeyak.waiting.domain.enums;
+
+// 액션 타입
+public enum CallType{ IMMINENT, FIRST, FINAL }

--- a/src/main/java/com/dayaeyak/waiting/domain/enums/CancelType.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/enums/CancelType.java
@@ -1,0 +1,3 @@
+package com.dayaeyak.waiting.domain.enums;
+
+public enum CancelType { OWNER, USER }

--- a/src/main/java/com/dayaeyak/waiting/domain/enums/WaitingStatus.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/enums/WaitingStatus.java
@@ -6,5 +6,14 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum WaitingStatus {
-    WAITING, CALLED, ENTERED, USER_COMING, USER_NOSHOW, OWNER_CALLED, USER_CALLED;
+    OWNER_CANCEL,
+    USER_CANCEL,
+    USER_NO_SHOW,
+    USER_ENTERED,
+
+    WAITING,
+    USER_COMING,
+    USER_ARRIVED,
+    FIRST_CALLED,
+    FINAL_CALLED,
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/repository/jpa/NoShowRepository.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/repository/jpa/NoShowRepository.java
@@ -7,14 +7,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.math.BigInteger;
+
 import java.util.List;
 
 @Repository
-public interface NoShowRepository extends JpaRepository<NoShow, BigInteger> {
+public interface NoShowRepository extends JpaRepository<NoShow, Long> {
     NoShow save(NoShow noShow);
-    Page<NoShow> findByRestaurantIdAndDeletedAtIsNull(BigInteger restaurantId, Pageable pageable);
-    List<NoShow> findByRestaurantIdAndDeletedAtIsNull(BigInteger restaurantId);
+    Page<NoShow> findByRestaurantIdAndDeletedAtIsNull(Long restaurantId, Pageable pageable);
+    List<NoShow> findByRestaurantIdAndDeletedAtIsNull(Long restaurantId);
 
 }
 

--- a/src/main/java/com/dayaeyak/waiting/domain/repository/jpa/WaitingOrderRepository.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/repository/jpa/WaitingOrderRepository.java
@@ -1,0 +1,20 @@
+package com.dayaeyak.waiting.domain.repository.jpa;
+
+import com.dayaeyak.waiting.domain.entity.WaitingOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
+
+import java.math.BigInteger;
+
+
+public interface WaitingOrderRepository extends JpaRepository<WaitingOrder, BigInteger> {
+
+
+}
+
+//public interface WaitingOrderRepository extends CrudRepository<WaitingOrder, BigInteger> {
+//
+//
+//}
+
+

--- a/src/main/java/com/dayaeyak/waiting/domain/repository/jpa/WaitingOrderRepository.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/repository/jpa/WaitingOrderRepository.java
@@ -4,15 +4,15 @@ import com.dayaeyak.waiting.domain.entity.WaitingOrder;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.CrudRepository;
 
-import java.math.BigInteger;
 
 
-public interface WaitingOrderRepository extends JpaRepository<WaitingOrder, BigInteger> {
+
+public interface WaitingOrderRepository extends JpaRepository<WaitingOrder, Long> {
 
 
 }
 
-//public interface WaitingOrderRepository extends CrudRepository<WaitingOrder, BigInteger> {
+//public interface WaitingOrderRepository extends CrudRepository<WaitingOrder, Long> {
 //
 //
 //}

--- a/src/main/java/com/dayaeyak/waiting/domain/repository/jpa/WaitingOrderRepository.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/repository/jpa/WaitingOrderRepository.java
@@ -1,15 +1,15 @@
 package com.dayaeyak.waiting.domain.repository.jpa;
 
+import com.dayaeyak.waiting.domain.entity.Waiting;
 import com.dayaeyak.waiting.domain.entity.WaitingOrder;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.CrudRepository;
 
-
+import java.util.List;
 
 
 public interface WaitingOrderRepository extends JpaRepository<WaitingOrder, Long> {
-
-
+    WaitingOrder findDistinctFirstByWaitingId(Long waitingId);
 }
 
 //public interface WaitingOrderRepository extends CrudRepository<WaitingOrder, Long> {

--- a/src/main/java/com/dayaeyak/waiting/domain/repository/jpa/WaitingRepository.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/repository/jpa/WaitingRepository.java
@@ -6,14 +6,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.math.BigInteger;
+
 import java.util.List;
 
 @Repository
-public interface WaitingRepository extends JpaRepository<Waiting, BigInteger> {
+public interface WaitingRepository extends JpaRepository<Waiting, Long> {
     Waiting save(Waiting waiting);
-    Page<Waiting> findByRestaurantIdAndDeletedAtIsNull(BigInteger restaurantId, Pageable pageable);
-    List<Waiting> findByRestaurantIdAndDeletedAtIsNull(BigInteger restaurantId);
+    Page<Waiting> findByRestaurantIdAndDeletedAtIsNull(Long restaurantId, Pageable pageable);
+    List<Waiting> findByRestaurantIdAndDeletedAtIsNull(Long restaurantId);
 
 }
 

--- a/src/main/java/com/dayaeyak/waiting/domain/service/NoShowService.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/service/NoShowService.java
@@ -17,7 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.math.BigInteger;
+
 import java.util.List;
 
 @Service
@@ -38,14 +38,14 @@ public class NoShowService {
         return new NoShowCreateResponseDto(savedNoShow.getNoShowId());
     }
 
-    public NoShowResponseDto getNoShow(BigInteger noShowID){
+    public NoShowResponseDto getNoShow(Long noShowID){
         NoShow noshow = noShowRepository.findById(noShowID)
                 .orElseThrow(() -> new EntityNotFoundException());
         return NoShowResponseDto.from(noshow);
     }
 
     public NoShowListResponseDto getNoShows(
-            BigInteger restaurantId,
+            Long restaurantId,
             int page,
             int size
     ){
@@ -58,7 +58,7 @@ public class NoShowService {
         return new NoShowListResponseDto(result.getTotalElements(), data);
     }
 
-    public void deleteNoShow(BigInteger noShowID){
+    public void deleteNoShow(Long noShowID){
         NoShow noshow = noShowRepository.findById(noShowID)
                 .orElseThrow(() -> new EntityNotFoundException());
 
@@ -66,7 +66,7 @@ public class NoShowService {
         noshow.delete();
     }
 
-    public void deleteNoShowAll(BigInteger restaurantId){
+    public void deleteNoShowAll(Long restaurantId){
         List<NoShow> noshowList = noShowRepository.findByRestaurantIdAndDeletedAtIsNull(restaurantId);
         if (noshowList.isEmpty()) return;
 

--- a/src/main/java/com/dayaeyak/waiting/domain/service/WaitingActionService.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/service/WaitingActionService.java
@@ -13,7 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.math.BigInteger;
+
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.Map;
@@ -28,7 +28,7 @@ public class WaitingActionService {
     private final WaitingOrderRepository waitingOrderRepository;
 
     // 노쇼 처리 - 고도화때 작업 처리반 쪽으로 넘기기
-    public WaitingUpdateResponseDto updateWaiting(BigInteger waitingId, String action, Map<String, Object> payload){
+    public WaitingUpdateResponseDto updateWaiting(Long waitingId, String action, Map<String, Object> payload){
         return switch(action.toLowerCase()) {
             case "waiting_call" -> call(waitingId, payload);
             case "waiting_user_coming" -> user_coming(waitingId, payload);
@@ -39,7 +39,7 @@ public class WaitingActionService {
         };
     }
 
-    private WaitingUpdateResponseDto call(BigInteger waitingId, Map<String, Object> payload){
+    private WaitingUpdateResponseDto call(Long waitingId, Map<String, Object> payload){
         CallType callType = requireEnum(payload, "type", CallType.class); // IMMINENT/FIRST/FINAL
 
         WaitingOrder waitingOrder = waitingOrderRepository.findById(waitingId)
@@ -68,7 +68,7 @@ public class WaitingActionService {
         return new WaitingUpdateResponseDto(waitingId);
     }
 
-    private WaitingUpdateResponseDto user_coming(BigInteger waitingId, Map<String, Object> payload){
+    private WaitingUpdateResponseDto user_coming(Long waitingId, Map<String, Object> payload){
         WaitingOrder waitingOrder = waitingOrderRepository.findById(waitingId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
 
@@ -88,7 +88,7 @@ public class WaitingActionService {
         return new WaitingUpdateResponseDto(waitingId);
     }
 
-    private WaitingUpdateResponseDto user_arrived(BigInteger waitingId, Map<String, Object> payload){
+    private WaitingUpdateResponseDto user_arrived(Long waitingId, Map<String, Object> payload){
         WaitingOrder waitingOrder = waitingOrderRepository.findById(waitingId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
 
@@ -104,7 +104,7 @@ public class WaitingActionService {
         return new WaitingUpdateResponseDto(waitingId);
     }
 
-    private WaitingUpdateResponseDto cancel(BigInteger waitingId, Map<String, Object> payload){
+    private WaitingUpdateResponseDto cancel(Long waitingId, Map<String, Object> payload){
         CancelType cancelType = requireEnum(payload, "type", CancelType.class); // OWNER, USER
 
         WaitingOrder waitingOrder = waitingOrderRepository.findById(waitingId)
@@ -140,7 +140,7 @@ public class WaitingActionService {
         return new WaitingUpdateResponseDto(waitingId);
     }
 
-    private WaitingUpdateResponseDto entered(BigInteger waitingId, Map<String, Object> payload){
+    private WaitingUpdateResponseDto entered(Long waitingId, Map<String, Object> payload){
         WaitingOrder waitingOrder = waitingOrderRepository.findById(waitingId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
 

--- a/src/main/java/com/dayaeyak/waiting/domain/service/WaitingActionService.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/service/WaitingActionService.java
@@ -16,6 +16,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.util.List;
 import java.util.Map;
 
 
@@ -42,8 +43,10 @@ public class WaitingActionService {
     private WaitingUpdateResponseDto call(Long waitingId, Map<String, Object> payload){
         CallType callType = requireEnum(payload, "type", CallType.class); // IMMINENT/FIRST/FINAL
 
-        WaitingOrder waitingOrder = waitingOrderRepository.findById(waitingId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        WaitingOrder waitingOrder = waitingOrderRepository.findDistinctFirstByWaitingId(waitingId);
+        if(waitingOrder == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
 
         switch (callType) {
             // case IMMINENT -> 앞에서 2팀에게 순서임박 자동 호출 (고도화 때 작업 처리반에서 진행 예정, 알람한테 요청)
@@ -69,8 +72,10 @@ public class WaitingActionService {
     }
 
     private WaitingUpdateResponseDto user_coming(Long waitingId, Map<String, Object> payload){
-        WaitingOrder waitingOrder = waitingOrderRepository.findById(waitingId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        WaitingOrder waitingOrder = waitingOrderRepository.findDistinctFirstByWaitingId(waitingId);
+        if(waitingOrder == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
 
         Object tmp = payload.get("move_time");
         Long moveTime = Long.parseLong(tmp.toString());
@@ -89,8 +94,10 @@ public class WaitingActionService {
     }
 
     private WaitingUpdateResponseDto user_arrived(Long waitingId, Map<String, Object> payload){
-        WaitingOrder waitingOrder = waitingOrderRepository.findById(waitingId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        WaitingOrder waitingOrder = waitingOrderRepository.findDistinctFirstByWaitingId(waitingId);
+        if(waitingOrder == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
 
         waitingOrder.setWaitingStatus(WaitingStatus.USER_ARRIVED);
 
@@ -107,8 +114,10 @@ public class WaitingActionService {
     private WaitingUpdateResponseDto cancel(Long waitingId, Map<String, Object> payload){
         CancelType cancelType = requireEnum(payload, "type", CancelType.class); // OWNER, USER
 
-        WaitingOrder waitingOrder = waitingOrderRepository.findById(waitingId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        WaitingOrder waitingOrder = waitingOrderRepository.findDistinctFirstByWaitingId(waitingId);
+        if(waitingOrder == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
 
         Waiting waiting = waitingRepository.findById(waitingId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
@@ -141,8 +150,10 @@ public class WaitingActionService {
     }
 
     private WaitingUpdateResponseDto entered(Long waitingId, Map<String, Object> payload){
-        WaitingOrder waitingOrder = waitingOrderRepository.findById(waitingId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        WaitingOrder waitingOrder = waitingOrderRepository.findDistinctFirstByWaitingId(waitingId);
+        if(waitingOrder == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
 
         waitingOrder.setWaitingStatus(WaitingStatus.USER_ENTERED);
 

--- a/src/main/java/com/dayaeyak/waiting/domain/service/WaitingActionService.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/service/WaitingActionService.java
@@ -1,7 +1,168 @@
 package com.dayaeyak.waiting.domain.service;
 
+import com.dayaeyak.waiting.domain.dto.response.WaitingUpdateResponseDto;
+import com.dayaeyak.waiting.domain.entity.Waiting;
+import com.dayaeyak.waiting.domain.enums.CallType;
+import com.dayaeyak.waiting.domain.enums.CancelType;
+import com.dayaeyak.waiting.domain.enums.WaitingStatus;
+import com.dayaeyak.waiting.domain.entity.WaitingOrder;
+import com.dayaeyak.waiting.domain.repository.jpa.WaitingOrderRepository;
+import com.dayaeyak.waiting.domain.repository.jpa.WaitingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigInteger;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Map;
+
 
 @Service
+@RequiredArgsConstructor
+
 public class WaitingActionService {
+
+    private final WaitingRepository waitingRepository;
+    private final WaitingOrderRepository waitingOrderRepository;
+
+    // 노쇼 처리 - 고도화때 작업 처리반 쪽으로 넘기기
+    public WaitingUpdateResponseDto updateWaiting(BigInteger waitingId, String action, Map<String, Object> payload){
+        return switch(action.toLowerCase()) {
+            case "waiting_call" -> call(waitingId, payload);
+            case "waiting_user_coming" -> user_coming(waitingId, payload);
+            case "waiting_user_arrived" -> user_arrived(waitingId, payload);
+            case "waiting_cancel" -> cancel(waitingId, payload);
+            case "waiting_entered" -> entered(waitingId, payload);
+            default -> throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "지원하지 않는 Action 입니다.");
+        };
+    }
+
+    private WaitingUpdateResponseDto call(BigInteger waitingId, Map<String, Object> payload){
+        CallType callType = requireEnum(payload, "type", CallType.class); // IMMINENT/FIRST/FINAL
+
+        WaitingOrder waitingOrder = waitingOrderRepository.findById(waitingId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        switch (callType) {
+            // case IMMINENT -> 앞에서 2팀에게 순서임박 자동 호출 (고도화 때 작업 처리반에서 진행 예정, 알람한테 요청)
+            case FIRST -> {
+                waitingOrder.setWaitingStatus(WaitingStatus.FIRST_CALLED);
+                // 알람한테 요청
+                // 고도화때 작업 처리반 쪽으로 넘기기
+            }
+            case FINAL -> {
+                waitingOrder.setWaitingStatus(WaitingStatus.FINAL_CALLED);
+                // 알람한테 요청
+                // 고도화때 작업 처리반 쪽으로 넘기기
+            }
+            default -> throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "지원하지 않는 call Type입니다.");
+        }
+
+        // 배포전에 외국 시간으로 바꾸기
+        waitingOrder.setLastCallAt(OffsetDateTime.now(ZoneId.of("Asia/Seoul")).toString());
+        waitingOrder.setDeadline(OffsetDateTime.now(ZoneId.of("Asia/Seoul")).plusMinutes(10).toString());
+
+        waitingOrderRepository.save(waitingOrder);
+        return new WaitingUpdateResponseDto(waitingId);
+    }
+
+    private WaitingUpdateResponseDto user_coming(BigInteger waitingId, Map<String, Object> payload){
+        WaitingOrder waitingOrder = waitingOrderRepository.findById(waitingId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        Object tmp = payload.get("move_time");
+        Long moveTime = Long.parseLong(tmp.toString());
+
+        waitingOrder.setWaitingStatus(WaitingStatus.USER_COMING);
+
+        // 알람한테 요청
+        // 고도화때 작업 처리반 쪽으로 넘기기
+
+        // 배포전에 외국 시간으로 바꾸기
+        waitingOrder.setDeadline(OffsetDateTime.now(ZoneId.of("Asia/Seoul")).plusMinutes(moveTime).toString());
+
+        waitingOrderRepository.save(waitingOrder);
+
+        return new WaitingUpdateResponseDto(waitingId);
+    }
+
+    private WaitingUpdateResponseDto user_arrived(BigInteger waitingId, Map<String, Object> payload){
+        WaitingOrder waitingOrder = waitingOrderRepository.findById(waitingId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        waitingOrder.setWaitingStatus(WaitingStatus.USER_ARRIVED);
+
+        // 알람한테 요청
+        // 고도화때 작업 처리반 쪽으로 넘기기
+
+        // 배포전에 외국 시간으로 바꾸기
+        waitingOrder.setDeadline(OffsetDateTime.now(ZoneId.of("Asia/Seoul")).toString());
+
+        waitingOrderRepository.save(waitingOrder);
+        return new WaitingUpdateResponseDto(waitingId);
+    }
+
+    private WaitingUpdateResponseDto cancel(BigInteger waitingId, Map<String, Object> payload){
+        CancelType cancelType = requireEnum(payload, "type", CancelType.class); // OWNER, USER
+
+        WaitingOrder waitingOrder = waitingOrderRepository.findById(waitingId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        Waiting waiting = waitingRepository.findById(waitingId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        switch (cancelType) {
+            case OWNER -> {
+                waitingOrder.setWaitingStatus(WaitingStatus.OWNER_CANCEL);
+                waiting.setWaitingStatus(WaitingStatus.OWNER_CANCEL);
+                // 알람한테 요청
+                // 고도화때 작업 처리반 쪽으로 넘기기
+            }
+            case USER -> {
+                waitingOrder.setWaitingStatus(WaitingStatus.USER_CANCEL);
+                waiting.setWaitingStatus(WaitingStatus.USER_CANCEL);
+                // 알람한테 요청
+                // 고도화때 작업 처리반 쪽으로 넘기기
+            }
+            default -> throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "지원하지 않는 call Type입니다.");
+        }
+
+        // 배포전에 외국 시간으로 바꾸기
+
+        // 레디스에서 내리고
+        // DB에 기록
+
+        waitingOrderRepository.save(waitingOrder);
+        waitingRepository.save(waiting);
+
+        return new WaitingUpdateResponseDto(waitingId);
+    }
+
+    private WaitingUpdateResponseDto entered(BigInteger waitingId, Map<String, Object> payload){
+        WaitingOrder waitingOrder = waitingOrderRepository.findById(waitingId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        waitingOrder.setWaitingStatus(WaitingStatus.USER_ENTERED);
+
+        // 알람한테 요청
+        // 고도화때 작업 처리반 쪽으로 넘기기
+
+        waitingOrderRepository.save(waitingOrder);
+        return new WaitingUpdateResponseDto(waitingId);
+    }
+
+
+
+
+    private static <E extends Enum<E>> E requireEnum(Map<String,Object> m, String key, Class<E> type){
+        if (m == null) throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "요청 바디가 필요합니다. ");
+        Object v = m.get(key);
+        if (v == null) throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "필수값 누락: "+key);
+        try { return Enum.valueOf(type, v.toString().trim().toUpperCase()); }
+        catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "허용되지 않는 값: " + key + "=" + v);
+        }
+    }
 }

--- a/src/main/java/com/dayaeyak/waiting/domain/service/WaitingService.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/service/WaitingService.java
@@ -6,6 +6,8 @@ import com.dayaeyak.waiting.domain.dto.response.WaitingListResponseDto;
 import com.dayaeyak.waiting.domain.dto.response.WaitingResponseDto;
 import com.dayaeyak.waiting.domain.entity.Waiting;
 import com.dayaeyak.waiting.domain.enums.WaitingStatus;
+import com.dayaeyak.waiting.domain.entity.WaitingOrder;
+import com.dayaeyak.waiting.domain.repository.jpa.WaitingOrderRepository;
 import com.dayaeyak.waiting.domain.repository.jpa.WaitingRepository;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
@@ -16,8 +18,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-
 import java.math.BigInteger;
+import java.sql.Time;
+import java.time.LocalTime;
 import java.util.List;
 
 @Service
@@ -25,6 +28,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WaitingService {
 
+
+    private final WaitingOrderRepository waitingOrderRepository;
     private final WaitingRepository waitingRepository;
 
     public WaitingCreateResponseDto register(WaitingCreateRequestDto requestDto){
@@ -37,8 +42,27 @@ public class WaitingService {
                 .build();
         Waiting savedWaiting = waitingRepository.save(waiting);
 
-        return new WaitingCreateResponseDto(savedWaiting.getWaitingId());
+
+
+        BigInteger savedWaitingId = savedWaiting.getWaitingId();
+        // 추후에 레디스에 올려야함
+        Time initialTime = Time.valueOf(LocalTime.now());
+
+        WaitingOrder waitingOrder = WaitingOrder.builder()
+                .waitingId(waiting.getWaitingId())
+                .restaurantId(waiting.getRestaurantId())
+                .waitingStatus(waiting.getWaitingStatus())
+                .initialTime(initialTime.toString())
+                .build();
+
+        waitingOrderRepository.save(waitingOrder);
+
+        // 사장에게 등록되었다는 알람 보내야함
+
+        return new WaitingCreateResponseDto(savedWaitingId);
     }
+
+
 
     public WaitingResponseDto getWaiting(BigInteger waitingId){
         Waiting waiting = waitingRepository.findById(waitingId)

--- a/src/main/java/com/dayaeyak/waiting/domain/service/WaitingService.java
+++ b/src/main/java/com/dayaeyak/waiting/domain/service/WaitingService.java
@@ -18,7 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.math.BigInteger;
+
 import java.sql.Time;
 import java.time.LocalTime;
 import java.util.List;
@@ -44,7 +44,7 @@ public class WaitingService {
 
 
 
-        BigInteger savedWaitingId = savedWaiting.getWaitingId();
+        Long savedWaitingId = savedWaiting.getWaitingId();
         // 추후에 레디스에 올려야함
         Time initialTime = Time.valueOf(LocalTime.now());
 
@@ -64,14 +64,14 @@ public class WaitingService {
 
 
 
-    public WaitingResponseDto getWaiting(BigInteger waitingId){
+    public WaitingResponseDto getWaiting(Long waitingId){
         Waiting waiting = waitingRepository.findById(waitingId)
                 .orElseThrow(() -> new EntityNotFoundException());
         return WaitingResponseDto.from(waiting);
     }
 
     public WaitingListResponseDto getWaitings(
-            BigInteger restaurantId,
+            Long restaurantId,
             int page,
             int size
     ){
@@ -84,7 +84,7 @@ public class WaitingService {
         return new WaitingListResponseDto(result.getTotalElements(), data);
     }
 
-    public void deleteWaiting(BigInteger waitingId){
+    public void deleteWaiting(Long waitingId){
         Waiting waiting = waitingRepository.findById(waitingId)
                 .orElseThrow(() -> new EntityNotFoundException());
 
@@ -92,7 +92,7 @@ public class WaitingService {
         waiting.delete();
     }
 
-    public void deleteWaitingAll(BigInteger restaurantId){
+    public void deleteWaitingAll(Long restaurantId){
         List<Waiting> waitingList = waitingRepository.findByRestaurantIdAndDeletedAtIsNull(restaurantId);
         if (waitingList.isEmpty()) return;
 


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 간단한 요약 -->
웨이팅 상태 업데이트 기능을 추가했습니다. 

## 💫 구현 및 변경 사항 (Details)

<!--- 구체적인 개발 사항 -->
1. 웨이팅 팀 입장, 사용자 도착, 사용자 이동중, 사장 웨이팅 취소, 손님 웨이팅 취소, 팀 호출, 팀 호출(최후통첩) 업데이트 메서드 추가
2. BigInteger타입 Long으로 일괄 변경 
3. 웨이팅 순서 엔티티 호출 방식 수정

## 📸스크린샷

<!--- API 테스트 결과 스크린샷 -->
<img width="714" height="671" alt="^^ 안녕하세요? " src="https://github.com/user-attachments/assets/8080a522-83bf-4e4f-a221-18a0d502fa18" />

## ✅ 체크리스트

- [x] 코드 정상 작동 테스트 완료
- [x] 관련 문서(API 문서, 위키 등) 업데이트
- [x] 팀의 코드 컨벤션/스타일 가이드 준수
- [x] Reviewers에 팀원 등록


## 💬 TODO 

1. 글로벌 에러 처리 추가 예정
2. 사용자 권한별 처리 추가 예정
3. 레디스 붙여서 상태관리 예정
* 고도화 기간에 진행 예정

## 기타/주의사항
- 
- 
-